### PR TITLE
add missing dependency logilab-common

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import sys
 import setuptools
 
-requires = ["pylint"]
+requires = ["pylint", "logilab-common"]
 
 console_script = """
 [console_scripts]


### PR DESCRIPTION
It seems pylint has stopped depending on logilab-common, but pylint-patcher still does. This adds the dependency explicitly so that installing pylint-patcher pulls the necessary packages with it.
